### PR TITLE
Fix deprecated configs

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,7 +1,6 @@
 set -g default-command "reattach-to-user-namespace -l zsh"
 # tmux display things in 256 colors
 set -g default-terminal "screen-256color"
-set -g status-utf8 on
 
 # automatically renumber tmux windows
 set -g renumber-windows on
@@ -62,10 +61,7 @@ bind -r L resize-pane -R 10
 # enable mouse support for switching panes/windows
 # NOTE: This breaks selecting/copying text on OSX
 # To select text as expected, hold Option to disable it (iTerm2)
-setw -g mode-mouse on
-set -g mouse-select-pane on
-set -g mouse-resize-pane on
-set -g mouse-select-window on
+setw -g mouse on
 
 # set vi mode for copy mode
 setw -g mode-keys vi


### PR DESCRIPTION
Hi thank you for these awesome dotfiles, but I just noticed some deprecation while configuring tmux **v2.2** in my new machine, so basically I am removing these

`set -g status-utf8 on` which is no longer necessary 

and

```
set -g mouse-select-pane on
set -g mouse-resize-pane on
set -g mouse-select-window on
```

will be replaced by `setw -g mouse on`
